### PR TITLE
Resolves finish() bug

### DIFF
--- a/src/dataclay/api/__init__.py
+++ b/src/dataclay/api/__init__.py
@@ -311,6 +311,7 @@ def finish():
     finish_tracing()
     getRuntime().stop_runtime()
     _initialized = False
+    _connection_initialized = False
 
 ######################################
 # Static initialization of dataClay


### PR DESCRIPTION
Currently, _connection_initialized not set to False but finish()
It results in failure during init_connection() on consecutive runs:
https://github.com/kpavel/pyclay/blob/master/src/dataclay/api/__init__.py#L72

Closes #50